### PR TITLE
Call MDFNI_Reset() instead of MDFNI_Power() in retro_reset()

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -322,8 +322,7 @@ RETRO_API void retro_set_controller_port_device(unsigned port, unsigned device)
 
 RETRO_API void retro_reset(void)
 {
- // MDFNI_Reset();
- MDFNI_Power();
+ MDFNI_Reset();
 }
 
 static void UpdateInput(void)


### PR DESCRIPTION
This will result in a more desirable soft reset like in other SNES cores.