### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,8 @@ else ifneq (,$(findstring cortexa9,$(platform)))
    FLAGS += -marm -mcpu=cortex-a9
    ASFLAGS += -mcpu=cortex-a9
 endif
+   LDFLAGS += -pthread
+   FLAGS += -pthread
    FLAGS += -marm
 ifneq (,$(findstring neon,$(platform)))
    FLAGS += -mfpu=neon


### PR DESCRIPTION
"armv" platform is recognized by the makefile, but actual compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts).