### PR TITLE
Fix Windows crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,7 @@ WINDOWS_VERSION=1
 
 else
    TARGET := $(TARGET_NAME)_libretro.dll
+   PSS_STYLE := 2
    CC ?= gcc
    CXX ?= g++
    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T

--- a/mednafen/config.h
+++ b/mednafen/config.h
@@ -15,9 +15,9 @@
 #define WANT_SNES_FAUST_EMU 1
 
 #if PSS_STYLE == 2
-#if defined(_MSC_VER) || defined(_WIN32)
- #define WIN32
-#endif
+//#if defined(_MSC_VER) || defined(_WIN32)
+// #define WIN32
+//#endif
  #define PSS "\\"
  #define MDFN_PS '\\'
 #elif PSS_STYLE == 1


### PR DESCRIPTION
Path separators are causing crashes on startup on Windows, more details here: https://github.com/libretro/supafaust/issues/20#issuecomment-1596175603

Still not sure about the `WIN32` define but so far in my tests it doesn't seem to affect anything... plus it wasn't defined previously when the core was still working so I guess this is fine.

Closes #20