### PR TITLE
Honor first scanline and last scanline settings without reloading the core.

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -245,6 +245,14 @@ static void pipe_option_bool(const char* lr_name, const char* mdfn_name)
  MDFNI_SetSetting(mdfn_name, v ? "1" : "0");
 }
 
+static void check_variables(bool loaded)
+{
+   pipe_option("supafaust_slstart", "snes_faust.slstart");
+   pipe_option("supafaust_slend", "snes_faust.slend");
+   pipe_option("supafaust_slstartp", "snes_faust.slstartp");
+   pipe_option("supafaust_slendp", "snes_faust.slendp");
+}
+
 MDFN_COLD RETRO_API void retro_init(void)
 {
  assert(!Initialized);
@@ -459,6 +467,12 @@ RETRO_API void retro_run(void)
  //
  //
   DoFrame(surf.get());
+
+  bool updated = false;
+  if (cb.environment(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
+  {
+      check_variables(true);
+  }
 }
 
 RETRO_API size_t retro_serialize_size(void)

--- a/mednafen/snes_faust/ppu_common.inc
+++ b/mednafen/snes_faust/ppu_common.inc
@@ -1348,6 +1348,11 @@ void PPU_StartFrame(EmulateSpecStruct* espec)
  //
  //
  //
+ unsigned sls = MDFN_GetSettingUI(PAL ? "snes_faust.slstartp" : "snes_faust.slstart");
+ unsigned sle = MDFN_GetSettingUI(PAL ? "snes_faust.slendp" : "snes_faust.slend");
+ SLDRH = sle + 1 - sls;
+ //
+ //
  es->InterlaceOn = false;
  es->DisplayRect.x = 0;
  es->DisplayRect.w = 256;


### PR DESCRIPTION
This makes the core apply the first and last scanline settings in the core options without having to reload the core, by simply returning to the emulation as with other cores.

This is done by simply piping the related settings to the MDFN side (only when there are changes, not on every frame) and then reading and applying them each frame, just like other cores to.