### PR TITLE
Fix netplay "No core found" error

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -308,7 +308,7 @@ MDFN_COLD RETRO_API void retro_get_system_info(retro_system_info* info)
  assert(info);
  //
  memset(info, 0, sizeof(*info));
- info->library_name = "Supafaust";
+ info->library_name = "Beetle Supafaust";
  info->library_version = MEDNAFEN_VERSION GIT_VERSION;
  info->valid_extensions = "smc|swc|sfc|fig";
  info->need_fullpath = false;


### PR DESCRIPTION
Resolves https://github.com/libretro/supafaust/issues/21

libretro.cpp: change library_name to "Beetle Supafaust", fixes netplay

Before the library_name of "Supafaust" was getting [compared](https://github.com/libretro/RetroArch/blob/58752d0755452dc83355faf031136d17aa0da40a/tasks/task_netplay_find_content.c#L788) to "Beetle Supafaust" and getting marked as a different core for netplay.